### PR TITLE
deploy-shell-efi.sh: Fix partition num breaking on nvme0n1p1

### DIFF
--- a/uefi-shell/deploy-shell-efi.sh
+++ b/uefi-shell/deploy-shell-efi.sh
@@ -36,7 +36,7 @@ cp "$SHELL_EFI_SRC" "$DEST_EFI"
 
 PART_DEV=$(findmnt -no SOURCE "$ESP")
 DISK=$(lsblk -no PKNAME "$PART_DEV" | head -n1)
-PART_NUM=$(echo "$PART_DEV" | sed 's/[^0-9]*//g')
+PART_NUM=$(echo "$PART_DEV" | sed -E 's/.*[^0-9]([0-9]+)$/\1/')
 DISK_DEV="/dev/$DISK"
 
 echo "Registering UEFI boot entry..."


### PR DESCRIPTION
It was just getting all digits from the disk name, so  nvm0n1p1 resulted in part num `011` which was
interpreted as partiion number 11 resulting in
a broken boot entry in the UEFI boot manager.

Now only the last sequence of digits is taken
into account and returns `1` for both
`sda1` and `nvme0n1p1` creating
bootable UEFI Shell boot entries.